### PR TITLE
✨ Especialidades

### DIFF
--- a/app/especialidades/[slug]/page.tsx
+++ b/app/especialidades/[slug]/page.tsx
@@ -1,0 +1,58 @@
+import { Container } from '@/components/container';
+import {
+  fetchBlockContent,
+  fetchDatabaseContent,
+  fetchPageContent,
+} from '@/utils/notion';
+import { generateSlug } from '@/utils/utils';
+
+export async function generateStaticParams() {
+  const specialities = await fetchDatabaseContent(
+    process.env.NOTION_ESPECIALIDADES_DATABASE_ID!,
+  );
+
+  return specialities.map((speciality) => ({
+    slug: generateSlug((speciality.properties.Nome as any).title[0].plain_text),
+  }));
+}
+
+async function getPageData(slug: string) {
+  const database = await fetchDatabaseContent(
+    process.env.NOTION_ESPECIALIDADES_DATABASE_ID!,
+  );
+
+  const id = database.find(
+    (speciality) =>
+      generateSlug((speciality.properties.Nome as any).title[0].plain_text) ===
+      slug,
+  )?.id;
+
+  const page = await fetchPageContent(id!);
+
+  return { page, id };
+}
+
+export default async function Especialidade({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const { slug } = await params;
+  const { page, id } = await getPageData(slug);
+  const blocks = await fetchBlockContent(id!);
+
+  return (
+    <>
+      <Container>
+        <h1>{(page.properties.Nome as any).title[0].plain_text}</h1>
+        <div>
+          {blocks.map((block: any) => (
+            <div key={block.id}>
+              <div>{block.paragraph.rich_text[0].plain_text}</div>
+            </div>
+          ))}
+        </div>
+      </Container>
+    </>
+  );
+}

--- a/app/especialidades/page.tsx
+++ b/app/especialidades/page.tsx
@@ -1,0 +1,44 @@
+import { Container } from '@/components/container';
+import { SectionHeader } from '@/sections/section-header';
+import { fetchDatabaseContent } from '@/utils/notion';
+import { generateSlug } from '@/utils/utils';
+import Link from 'next/link';
+
+export default async function Especialidades() {
+  const specialities = await fetchDatabaseContent(
+    process.env.NOTION_ESPECIALIDADES_DATABASE_ID!,
+  );
+
+  return (
+    <>
+      <Container>
+        <SectionHeader
+          eyebrow="Especialidades"
+          title="Um cuidado completo para o seu sorriso"
+        />
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-x-8 gap-y-12">
+          {specialities.map((speciality) => (
+            <Link
+              href={`/especialidades/${generateSlug((speciality.properties.Nome as any).title[0].plain_text)}`}
+              key={speciality.id}
+              className="flex flex-col gap-6"
+            >
+              <div className="bg-background-neutral-subtle relative aspect-3/2 w-full object-cover" />
+              <div className="flex flex-col gap-3">
+                <h3 className="text-title-large font-medium">
+                  {(speciality.properties.Nome as any).title[0].plain_text}
+                </h3>
+                <p className="text-title-small text-foreground-neutral-subtle">
+                  {
+                    (speciality.properties.Descrição as any).rich_text[0]
+                      .plain_text
+                  }
+                </p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </Container>
+    </>
+  );
+}

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -1,0 +1,11 @@
+export function generateSlug(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Mn}/gu, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[\s]+/g, '-')
+    .replace(/[^\w\-]+/g, '')
+    .replace(/--+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}


### PR DESCRIPTION
[Especialidades](https://www.notion.so/zalodias/Especialidades-29057c1e961280998007ebae13cd249c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Especialidades index and dynamic detail pages backed by Notion, plus a shared slug generator utility.
> 
> - **Pages**
>   - Add `app/especialidades/page.tsx`: fetch Notion database (`NOTION_ESPECIALIDADES_DATABASE_ID`), render grid of specialties with name/description and links using slugified titles.
>   - Add `app/especialidades/[slug]/page.tsx`: generate static params from Notion, resolve page by slug, load page/blocks, and render title plus paragraph content.
> - **Utils**
>   - Add `utils/utils.ts` with `generateSlug` for normalized URL slugs; used in both pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acbb8b44da8d38461b36a5e8d2f29a9a36ab83bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->